### PR TITLE
Waiting and serving award xp

### DIFF
--- a/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
+++ b/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
@@ -223,6 +223,7 @@ namespace Gastronomy.Waiting
                         {
                             //Log.Message($"{actor.NameShortColored} didn't receive any silver from {patron.NameShortColored}.");
                             actor.jobs.curDriver.EndJobWith(JobCondition.Succeeded);
+                            actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                         }
                         else
                         {
@@ -232,10 +233,12 @@ namespace Gastronomy.Waiting
                                 // No register, just drop it
                                 actor.inventory.innerContainer.TryDrop(silver, ThingPlaceMode.Near, out silver);
                                 actor.jobs.curDriver.EndJobWith(JobCondition.Succeeded);
+                                actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                             }
                             curJob.SetTarget(silverInd, silver);
                             curJob.SetTarget(registerInd, register);
                             curJob.count = silver.stackCount;
+                            actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                         }
 
                         //Log.Message($"{actor.NameShortColored} has completed order for {patron.NameShortColored} with {food.Label}.");
@@ -283,7 +286,6 @@ namespace Gastronomy.Waiting
                 if (patron.jobs.curDriver is JobDriver_Dine patronDriver)
                 {
                     DiningUtility.GiveServiceThought(patron, toil.actor, patronDriver.HoursWaited);
-                    actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                 }
 
                 var symbol = food.def.uiIcon;

--- a/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
+++ b/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
@@ -223,7 +223,6 @@ namespace Gastronomy.Waiting
                         {
                             //Log.Message($"{actor.NameShortColored} didn't receive any silver from {patron.NameShortColored}.");
                             actor.jobs.curDriver.EndJobWith(JobCondition.Succeeded);
-                            actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                         }
                         else
                         {
@@ -233,13 +232,12 @@ namespace Gastronomy.Waiting
                                 // No register, just drop it
                                 actor.inventory.innerContainer.TryDrop(silver, ThingPlaceMode.Near, out silver);
                                 actor.jobs.curDriver.EndJobWith(JobCondition.Succeeded);
-                                actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                             }
                             curJob.SetTarget(silverInd, silver);
                             curJob.SetTarget(registerInd, register);
                             curJob.count = silver.stackCount;
-                            actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                         }
+                        actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
 
                         //Log.Message($"{actor.NameShortColored} has completed order for {patron.NameShortColored} with {food.Label}.");
                     }

--- a/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
+++ b/Source/RimWorld_Gastronomy/Waiting/Toils_Waiting.cs
@@ -82,7 +82,8 @@ namespace Gastronomy.Waiting
                 else
                 {
                     restaurant.Orders.CreateOrder(patron, desiredFood);
-                    
+                    toil.GetActor().skills.GetSkill(SkillDefOf.Social).Learn(150, false);
+
                     var symbol = desiredFood.def.uiIcon;
                     if (symbol != null) TryCreateBubble(patron, toil.actor, symbol);
                 }
@@ -282,6 +283,7 @@ namespace Gastronomy.Waiting
                 if (patron.jobs.curDriver is JobDriver_Dine patronDriver)
                 {
                     DiningUtility.GiveServiceThought(patron, toil.actor, patronDriver.HoursWaited);
+                    actor.skills.GetSkill(SkillDefOf.Social).Learn(150, false);
                 }
 
                 var symbol = food.def.uiIcon;


### PR DESCRIPTION
Each action (waiting and serving) awards 150 social xp, for a total of 300 social xp per patron. A single-passion social pawn would need to wait and serve 14 patrons to hit the daily cap of 4000 xp. A double passion social pawn needs to serve 9 patrons to hit the cap. This contribution is under the under the CC0 license, public domain.